### PR TITLE
libdns/desec: Bump libdns version to v0.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.9
-	github.com/libdns/libdns v0.2.2-0.20230501153445-5344f2e6777e
+	github.com/libdns/libdns v0.2.2
 	golang.org/x/exp v0.0.0-20230420155640-133eef4313cb
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
-github.com/libdns/libdns v0.2.2-0.20230501153445-5344f2e6777e h1:rQoZTxoOHpdC6eXnRSxKnpCfe4SqGvTd0aqz8ZsPTUw=
-github.com/libdns/libdns v0.2.2-0.20230501153445-5344f2e6777e/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 golang.org/x/exp v0.0.0-20230420155640-133eef4313cb h1:rhjz/8Mbfa8xROFiH+MQphmAmgqRM0bOMnytznhWEXk=
 golang.org/x/exp v0.0.0-20230420155640-133eef4313cb/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/provider.go
+++ b/provider.go
@@ -484,8 +484,8 @@ func libdnsRecords(rrs rrSet) ([]libdns.Record, error) {
 			Name:     name,
 			Value:    value,
 			TTL:      ttl,
-			Priority: prio,
-			Weight:   weight,
+			Priority: uint(prio),
+			Weight:   uint(weight),
 		})
 	}
 	return records, nil


### PR DESCRIPTION
libdns/desec: Bump libdns version to v0.2.2

I am building this plugin together with cloudflare. Since cloudflare does an indirect upgrade of the libdns version, the build fails.

This PR fixes the build as single module, or together with cloudflare.
